### PR TITLE
Update github:csmith/centauri v2.6.0 -> v2.6.1

### DIFF
--- a/centauri/Containerfile
+++ b/centauri/Containerfile
@@ -1,4 +1,4 @@
-# Generated from https://github.com/greboid/dockerfiles/blob/master/centauri/Containerfile.gotpl
+# Generated from centauri/Containerfile.gotpl
 # BOM: {"github:csmith/centauri":"v2.6.0","image:alpine":"7df57775ab85b95030a217e2322117b4a92ce539195fa28bd551b933320e83f9","image:base":"53bb0cbcb81a7955284c1f020e4fe49f7827ae61f3b733c1409e05d1b6d94e97","image:golang":"b1f54309ab4ef1f71571543ca4fb5a8e2c57f970e81fc8b5f71ef32c3eb91e3b"}
 
 FROM reg.g5d.dev/golang@sha256:b1f54309ab4ef1f71571543ca4fb5a8e2c57f970e81fc8b5f71ef32c3eb91e3b AS build


### PR DESCRIPTION
Update `github:csmith/centauri` from `v2.6.0` to `v2.6.1`.