### PR TITLE
Update github:miniflux/v2 2.2.19 -> 2.3.0

### DIFF
--- a/miniflux/Containerfile
+++ b/miniflux/Containerfile
@@ -1,4 +1,4 @@
-# Generated from https://github.com/greboid/dockerfiles/blob/master/miniflux/Containerfile.gotpl
+# Generated from miniflux/Containerfile.gotpl
 # BOM: {"github:miniflux/v2":"2.2.19","image:alpine":"7df57775ab85b95030a217e2322117b4a92ce539195fa28bd551b933320e83f9","image:base":"53bb0cbcb81a7955284c1f020e4fe49f7827ae61f3b733c1409e05d1b6d94e97","image:golang":"b1f54309ab4ef1f71571543ca4fb5a8e2c57f970e81fc8b5f71ef32c3eb91e3b"}
 
 FROM reg.g5d.dev/golang@sha256:b1f54309ab4ef1f71571543ca4fb5a8e2c57f970e81fc8b5f71ef32c3eb91e3b AS build


### PR DESCRIPTION
Update `github:miniflux/v2` from `2.2.19` to `2.3.0`.